### PR TITLE
perf: purge cache when `pendingCount` equal `0`

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -27,7 +27,10 @@ export default defineNuxtPlugin(() => {
       limitMap.set(pattern.pattern, (limit = pLimit(pattern.limit)));
     }
 
-    return limit(() => $fetch(...args));
+    return limit(() => $fetch(...args)
+      .finally(() => {
+        if(limit?.pendingCount === 0) limitMap.delete(pattern.pattern);
+      }));
   }) as typeof $fetch;
 
   Object.assign(globalThis.$fetch, $fetch);


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org). -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->


When concurrent requests are finished, remove them from the map to avoid unnecessary memory consumption.

playground test code

```ts
for(let i in [1, 2, 3, 4, 5]) {
  $fetch('https://httpstat.us/408')
    .then(async res => {
      await sleep(2000)
      console.log(i, ': ', res)
      return res;
    })
}

```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.