### PR TITLE
fix: resolve error raised by unneeded scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
     "lint:eslint": "eslint --fix",
     "lint:prettier": "prettier --write --log-level warn",
     "prepack": "pnpm build",
-    "prepare": "npx husky install",
-    "release": "bumpp && npm publish",
-    "postinstall": "npx husky install"
+    "release": "bumpp && npm publish"
   },
   "dependencies": {
     "@nuxt/kit": "^3.6.4",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "lint:eslint": "eslint --fix",
     "lint:prettier": "prettier --write --log-level warn",
     "prepack": "pnpm build",
-    "prepare": "husky install",
+    "prepare": "npx husky install",
     "release": "bumpp && npm publish",
-    "postinstall": "husky install"
+    "postinstall": "npx husky install"
   },
   "dependencies": {
     "@nuxt/kit": "^3.6.4",


### PR DESCRIPTION
Coming from https://github.com/nuxt/nuxt/issues/22212!

Sorry for the late reply, I needed to find the time to test it properly :)

There is currently this minor issue that I believe should be addressed, it is not safe to assume users of the module have husky installed!